### PR TITLE
Fix Feign client configuration and Kafka listener

### DIFF
--- a/hexagonal/hexagonal/build.gradle
+++ b/hexagonal/hexagonal/build.gradle
@@ -24,7 +24,9 @@ repositories {
 }
 
 ext {
-    set('springCloudVersion', '2021.0.4')
+    // Align Spring Cloud with the Spring Boot 3.x baseline
+    // Using the latest Spring Cloud Release Train compatible with Boot 3.5
+    set('springCloudVersion', '2025.0.0')
 }
 
 dependencies {

--- a/hexagonal/hexagonal/src/main/java/com/patrickriibeiro/hexagonal/adapters/in/consumer/ReceiveValidatedCpfConsumer.java
+++ b/hexagonal/hexagonal/src/main/java/com/patrickriibeiro/hexagonal/adapters/in/consumer/ReceiveValidatedCpfConsumer.java
@@ -8,7 +8,6 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
 @Component
-@KafkaListener(topics = "tp-cpf-validated", groupId = "oliveira")
 public class ReceiveValidatedCpfConsumer {
 
     @Autowired
@@ -17,6 +16,7 @@ public class ReceiveValidatedCpfConsumer {
     @Autowired
     private CustomerMessageMapper customerMessageMapper;
 
+    @KafkaListener(topics = "tp-cpf-validated", groupId = "oliveira")
     public void receive(CustomerMessage customerMessage){
         var customer = customerMessageMapper.toCustomer(customerMessage);
         updateCustomerInputPort.update(customer, customerMessage.getZipCode());


### PR DESCRIPTION
## Summary
- update Spring Cloud to a release train compatible with Spring Boot 3.5
- move `@KafkaListener` annotation to the proper method

## Testing
- `./gradlew test -i`
- `./gradlew bootRun --quiet` *(fails to connect to Kafka but application starts)*

------
https://chatgpt.com/codex/tasks/task_e_688a8a4b9014832bbadb7f74e6c5d326