### PR TITLE
Fix MapStruct-Lombok integration

### DIFF
--- a/hexagonal/hexagonal/build.gradle
+++ b/hexagonal/hexagonal/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.mapstruct:mapstruct:1.5.2.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.2.Final'
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
## Summary
- enable Lombok binding for MapStruct mappers

## Testing
- `./gradlew -p hexagonal/hexagonal clean test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_688bbdd2ecc0832b9360992f99bd377b