### PR TITLE
Allow config layer to access ports

### DIFF
--- a/hexagonal/hexagonal/src/test/java/com/patrickriibeiro/hexagonal/architecture/LayeredArchitectureTest.java
+++ b/hexagonal/hexagonal/src/test/java/com/patrickriibeiro/hexagonal/architecture/LayeredArchitectureTest.java
@@ -23,7 +23,7 @@ public class LayeredArchitectureTest {
             .whereLayer("AdaptersIn").mayOnlyBeAccessedByLayers("Config")
             .whereLayer("AdaptersOut").mayOnlyBeAccessedByLayers("Config")
             .whereLayer("UserCase").mayOnlyBeAccessedByLayers("Config")
-            .whereLayer("PortsIn").mayOnlyBeAccessedByLayers("UserCase","AdaptersIn")
-            .whereLayer("PortsOut").mayOnlyBeAccessedByLayers("UserCase","AdaptersOut")
-            .whereLayer("Config").mayNotAccessAnyLayer();
+            .whereLayer("PortsIn").mayOnlyBeAccessedByLayers("UserCase","AdaptersIn","Config")
+            .whereLayer("PortsOut").mayOnlyBeAccessedByLayers("UserCase","AdaptersOut","Config")
+            .whereLayer("Config").mayOnlyBeAccessedByLayers("Config");
 }


### PR DESCRIPTION
## Summary
- permit Config layer to depend on PortsIn and PortsOut in ArchUnit test
- ensure Config is only accessed by Config

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_688c2e68ae28832ba69a179d096ec309